### PR TITLE
Gap fix

### DIFF
--- a/frontend/src/scss/layout/_layout.scss
+++ b/frontend/src/scss/layout/_layout.scss
@@ -1,13 +1,20 @@
 html {
     .root {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+
         main {
             top: 24px;
             position: relative;
             display: flex;
             flex-wrap: wrap;
             max-width: 1020px;
-            margin-left: auto;
-            margin-right: auto;
+            margin: -16px;
+
+            & > * {
+                margin: 16px;
+            }
 
             // general layout styles (belong here so that the breakpoints stay the same on different pages)
             padding-left: 16px;

--- a/frontend/src/scss/pages/_about.scss
+++ b/frontend/src/scss/pages/_about.scss
@@ -9,11 +9,12 @@
     .about-us {
         display: flex;
         flex-direction: column;
-        row-gap: 16px;
         flex-basis: 325px;
         flex-grow: 10;
 
         .about-us__body {
+            margin-top: 16px;
+
             .about-us__gold-text {
                 color: variables.$gold;
             }
@@ -23,7 +24,6 @@
     .officers {
         display: flex;
         flex-direction: column;
-        row-gap: 16px;
         flex-basis: 350px;
         flex-grow: 1;
         flex-shrink: 0;
@@ -31,7 +31,11 @@
         .officers__list {
             display: flex;
             flex-direction: column;
-            row-gap: 16px;
+            margin-top: 16px;
+
+            .officer:not(:last-child) {
+                margin-bottom: 16px;
+            }
         }
 
         .officer {
@@ -61,8 +65,11 @@
         .pillars__list {
             display: flex;
             flex-direction: column;
-            row-gap: 16px;
             margin-top: 16px;
+
+            .pillar:not(:last-child) {
+                margin-bottom: 16px;
+            }
         }
 
         .pillar {

--- a/frontend/src/scss/pages/_about.scss
+++ b/frontend/src/scss/pages/_about.scss
@@ -4,8 +4,6 @@
 @use "../abstracts/variables";
 
 .about main {
-    gap: 32px;
-
     .about-us {
         display: flex;
         flex-direction: column;

--- a/frontend/src/scss/pages/_home.scss
+++ b/frontend/src/scss/pages/_home.scss
@@ -12,19 +12,23 @@
         flex-direction: column;
         flex-basis: 250px;
         flex-grow: 1;
-        row-gap: 16px;
 
         .deadlines__button {
             @include button.outline-color(rgba($color: variables.$gold, $alpha: 0.12));
 
             align-self: flex-start;
+            margin-top: 16px;
         }
 
         .deadlines__list {
             display: flex;
             flex-direction: column;
             position: relative;
-            row-gap: 16px;
+            margin-top: 16px;
+
+            .deadline:not(:last-child) {
+                margin-bottom: 16px;
+            }
         }
 
         .deadline {
@@ -36,7 +40,6 @@
             display: flex;
             flex-direction: column;
             flex-shrink: 0;
-            column-gap: initial;
             overflow: hidden;
 
             .deadline__top {
@@ -84,13 +87,15 @@
         flex-direction: column;
         flex-basis: 275px;
         flex-grow: 10;
-        row-gap: 16px;
 
         .announcements__list {
             display: flex;
             flex-direction: column;
-            row-gap: 16px;
-            column-gap: 16px;
+            margin-top: 16px;
+
+            .announcement:not(:last-child) {
+                margin-bottom: 16px;
+            }
         }
 
         .announcement {

--- a/frontend/src/scss/pages/_home.scss
+++ b/frontend/src/scss/pages/_home.scss
@@ -5,8 +5,6 @@
 @use "../abstracts/variables";
 
 .home main {
-    gap: 32px;
-
     .deadlines {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
After some analysis, the best option to support flex `gap` on all browsers was to not use it at all :(.  However, it turns out there are several different alternative methods to get the same outcome as flex `gap`.  When there is only one axis that flex children need to be spaced on, this snippet worked flawlessly (this is for the list of deadlines):

```css
.deadline:not(:last-child) {
    margin-bottom: 16px;
}
```

However, when the gap was both vertical and horizontal, it requires a little bit more trickery (this is for the main layout):

```css
main {
    /* ... other styles ... */
    margin: -16px;

        & > * {
            margin: 16px;
        }
}
```

This PR closes #4